### PR TITLE
Issues with Rails 3.2.x

### DIFF
--- a/lib/rails_default_url_options.rb
+++ b/lib/rails_default_url_options.rb
@@ -28,7 +28,7 @@
 
 unless defined?(DefaultUrlOptions)
 
-  DefaultUrlOptions = defined?(HashWithIndifferentAccess) ? HashWithIndifferentAccess.new : Hash.new
+  DefaultUrlOptions = Hash.new
 
   def DefaultUrlOptions.version
     '1.3.2'


### PR DESCRIPTION
Trying to upgrade our Rails app that uses default_url_options and "ArgumentError: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true" started popping up during our specs.

It looks like this change in Rails: https://github.com/rails/rails/commit/c41f08cefe6fa3747ee79001d9c88dc988e8064d makes the assumption that the keys will always be symbols.

Unfortunately this is happening:

```
>> default_url_options
=> {"host"=>"example.org", "protocol"=>"https://"}

>> default_url_options[:host]
=> "example.org"

>> {}.reverse_merge!(default_url_options)[:host]
=> nil
```

Simply changing DefaultUrlOptions from a HashWithIndifferentAccess to a Hash seems to fix all of our issues.  Thank you for your consideration.
